### PR TITLE
Lift size limit when RemoteHub tars are available for current workspace

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -177,8 +177,8 @@ async function _startServer(extensionUri: vscode.Uri, supportedLanguages: Suppor
 	// do not set a maxResults limit if RemoteHub has the full workspace contents
 	const remoteHub = vscode.extensions.getExtension('GitHub.remoteHub') ?? vscode.extensions.getExtension('GitHub.remoteHub-insiders');
 	const remoteHubApi = await remoteHub?.activate();
-	let hasFullWorkspaceContents = false;
-	if (remoteHubApi && remoteHubApi.hasWorkspaceContents && vscode.workspace.workspaceFolders) {
+	let hasFullWorkspaceContents = true;
+	if (remoteHubApi?.hasWorkspaceContents && vscode.workspace.workspaceFolders) {
 		for (const folder of vscode.workspace.workspaceFolders) {
 			hasFullWorkspaceContents = hasFullWorkspaceContents && (await remoteHubApi.hasWorkspaceContents(folder.uri));
 		}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -173,8 +173,9 @@ async function _startServer(extensionUri: vscode.Uri, supportedLanguages: Suppor
 		...Object.keys(vscode.workspace.getConfiguration('files', null).get('exclude') ?? {})
 	].join(',')}}`;
 
+	const remoteHub = vscode.extensions.getExtension('GitHub.remoteHub') ?? vscode.extensions.getExtension('GitHub.remoteHub-insiders');
 	const size = Math.max(0, vscode.workspace.getConfiguration('anycode').get<number>('symbolIndexSize', 100));
-	const init = Promise.resolve(vscode.workspace.findFiles(langPattern, exclude, size + 1).then(async uris => {
+	let init = Promise.resolve(vscode.workspace.findFiles(langPattern, exclude, remoteHub ? undefined : size + 1).then(async uris => {
 		console.info(`FOUND ${uris.length} files for ${langPattern}`);
 
 		const t1 = performance.now();
@@ -189,6 +190,11 @@ async function _startServer(extensionUri: vscode.Uri, supportedLanguages: Suppor
 		telemetry.sendTelemetryEvent('init', undefined, { numOfFiles: uris.length, indexSize: size, duration: performance.now() - t1 });
 
 	}));
+	// if RemoteHub is installed, wait for all workspaces' contents to finish loading before initializing
+	const remoteHubApi = await remoteHub?.activate();
+	if (remoteHubApi && remoteHubApi.workspaceContentsLoaded && vscode.workspace.workspaceFolders) {
+		init = Promise.all(vscode.workspace.workspaceFolders.map(folder => remoteHubApi.workspaceContentsLoaded(folder.uri))).then(async () => init);
+	}
 	// stop on server-end
 	const initCancel = new Promise(resolve => disposables.push(new vscode.Disposable(resolve)));
 	vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Building Index...' }, () => Promise.race([init, initCancel]));


### PR DESCRIPTION
You can install GitHub.remoteHub-insiders to consume the new `hasWorkspaceContents(workspaceUri: vscode.Uri)` API, which returns `true` if the `workspaceUri` is provided by a virtual provider that supports requesting the full workspace contents (currently, just GitHub provider URIs) and the workspace contents are currently locally available.