### PR TITLE
Use --follow-tags flag for git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ There is a **watch** task to build TS, either `npm run watch` or "F1 > Run Task 
 Push a tag to **publish** a new version to the marketplace: 
 
 * run `npm version path` and then
-* run `git push && git push --tag`
+* run `git push --follow-tags`
 
 ## Contributing
 


### PR DESCRIPTION
docs: https://git-scm.com/docs/git-push#Documentation/git-push.txt---follow-tags

The `--follow-tags` flags will make this one command instead of two, but it will also prevent pushing all of your local tags, and instead only pushes the ones that are missing from the remote but are pointing at commit-ish that are reachable from the refs being pushed. In practice this means that only the tag just created by `npm version` will be pushed ☺️ 