### PR TITLE
Azure DevOps - create pipeline based on the generic template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,33 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  branches:
+    include: ["*"]
+  tags:
+    include: ["*"]
+pr: none
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: main
+      endpoint: Monaco
+
+extends:
+  template: azure-pipelines/extension/stable.yml@templates
+  parameters:
+    buildSteps:
+      - script: npm install -ci
+        displayName: Install dependencies
+
+      - script: npm run compile
+        displayName: Compile extension
+
+      - script: npx playwright install-deps
+        displayName: Install operating system dependencies
+
+      - script: npm run test-server
+        displayName: Test extension
+      - name: Install operating system dependencies


### PR DESCRIPTION
The pipeline does not contain the equivalent of the `mymindstorm/setup-emsdk@v9` action. 