### PR TITLE
add support to self-suppress languages when a "real" language extension is available

### DIFF
--- a/anycode-c-sharp/package.json
+++ b/anycode-c-sharp/package.json
@@ -28,7 +28,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
+			},
+			"suppressedBy": [
+				"ms-dotnettools.csharp"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode-cpp/package.json
+++ b/anycode-cpp/package.json
@@ -28,7 +28,10 @@
 					"comments": "./queries/c/comments.scm",
 					"identifiers": "./queries/c/identifiers.scm",
 					"outline": "./queries/c/outline.scm"
-				}
+				},
+				"suppressedBy": [
+					"ms-vscode.cpptools"
+				]
 			},
 			{
 				"grammarPath": "./tree-sitter-cpp.wasm",
@@ -55,7 +58,10 @@
 					"comments": "./queries/cpp/comments.scm",
 					"identifiers": "./queries/cpp/identifiers.scm",
 					"outline": "./queries/cpp/outline.scm"
-				}
+				},
+				"suppressedBy": [
+					"ms-vscode.cpptools"
+				]
 			}
 		]
 	},

--- a/anycode-go/package.json
+++ b/anycode-go/package.json
@@ -28,7 +28,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
+			},
+			"suppressedBy": [
+				"golang.Go"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode-java/package.json
+++ b/anycode-java/package.json
@@ -29,7 +29,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
+			},
+			"suppressedBy": [
+				"redhat.java"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode-php/package.json
+++ b/anycode-php/package.json
@@ -32,7 +32,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
+			},
+			"suppressedBy": [
+				"bmewburn.vscode-intelephense-client"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode-python/package.json
+++ b/anycode-python/package.json
@@ -35,21 +35,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
-		},
-		"configurationDefaults": {
-			"[python]": {
-				"anycode.language.features": {
-					"definitions": true,
-					"workspaceSymbols": true,
-					"highlights": false,
-					"completions": false,
-					"references": false,
-					"outline": false,
-					"folding": false,
-					"diagnostics": false
-				}
-			}
+			},
+			"suppressedBy": [
+				"ms-python.python"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode-rust/package.json
+++ b/anycode-rust/package.json
@@ -29,7 +29,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
+			},
+			"suppressedBy": [
+				"rust-lang.rust"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode-typescript/package.json
+++ b/anycode-typescript/package.json
@@ -28,21 +28,10 @@
 				"locals": "./queries/locals.scm",
 				"outline": "./queries/outline.scm",
 				"references": "./queries/references.scm"
-			}
-		},
-		"configurationDefaults": {
-			"[typescript]": {
-				"anycode.language.features": {
-					"definitions": true,
-					"workspaceSymbols": true,
-					"highlights": false,
-					"completions": false,
-					"references": false,
-					"outline": false,
-					"folding": false,
-					"diagnostics": false
-				}
-			}
+			},
+			"suppressedBy": [
+				"vscode.typescript-language-features"
+			]
 		}
 	},
 	"scripts": {

--- a/anycode/shared/common/initOptions.ts
+++ b/anycode/shared/common/initOptions.ts
@@ -18,7 +18,8 @@ export class LanguageInfo {
 		readonly languageId: string,
 		readonly wasmUri: string,
 		readonly suffixes: string[],
-		readonly queries?: Queries
+		readonly queries?: Queries,
+		readonly suppressedBy?: string[]
 	) { }
 }
 


### PR DESCRIPTION
Allow language contributes like `anycode-typescript` to self-suppress them when a well-known language extension is available, e.g `vscode.typescript-language-features`. This helps to avoid false positives being mixed in with other results.