### PR TITLE
ci: add CI workflow and remove unused @playwright/test from language packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install anycode dependencies and compile
+        run: npm install
+        working-directory: anycode
+
+      - name: Lint
+        run: npm run lint
+        working-directory: anycode
+
+      - name: Test server
+        run: npm run test-server
+        working-directory: anycode
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+        working-directory: anycode/server
+
+      - name: Test anycode-c-sharp
+        run: npm install && npm test
+        working-directory: anycode-c-sharp
+
+      - name: Test anycode-cpp
+        run: npm install && npm test
+        working-directory: anycode-cpp
+
+      - name: Test anycode-go
+        run: npm install && npm test
+        working-directory: anycode-go
+
+      - name: Test anycode-java
+        run: npm install && npm test
+        working-directory: anycode-java
+
+      - name: Test anycode-kotlin
+        run: npm install && npm test
+        working-directory: anycode-kotlin
+
+      - name: Test anycode-php
+        run: npm install && npm test
+        working-directory: anycode-php
+
+      - name: Test anycode-python
+        run: npm install && npm test
+        working-directory: anycode-python
+
+      - name: Test anycode-rust
+        run: npm install && npm test
+        working-directory: anycode-rust
+
+      - name: Test anycode-typescript
+        run: npm install && npm test
+        working-directory: anycode-typescript

--- a/anycode-c-sharp/package-lock.json
+++ b/anycode-c-sharp/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"devDependencies": {
-				"@playwright/test": "^1.14.1",
+				"@playwright/test": "^1.58.2",
 				"tree-sitter-c-sharp": "^0.23.1",
 				"tree-sitter-cli": "^0.20.8"
 			},
@@ -19,26 +19,33 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.2.tgz",
-			"integrity": "sha512-umaEAIwQGfbezixg3raSOraqbQGSqZP988sOaMdpA2wj3Dr6ykOscrMukyK3U6edxhpS0N8kguAFZoHwCEfTig==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.23.2"
+				"playwright": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
-		"node_modules/@types/node": {
-			"version": "18.0.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-			"integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
-			"dev": true
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/node-addon-api": {
 			"version": "8.3.1",
@@ -60,16 +67,34 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
-		"node_modules/playwright-core": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.2.tgz",
-			"integrity": "sha512-UGbutIr0nBALDHWW/HcXfyK6ZdmefC99Moo4qyTr89VNIkYZuDrW8Sw554FyFUamcFSdKOgDPk6ECSkofGIZjQ==",
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"dev": true,
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/tree-sitter-c-sharp": {
@@ -104,20 +129,20 @@
 	},
 	"dependencies": {
 		"@playwright/test": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.2.tgz",
-			"integrity": "sha512-umaEAIwQGfbezixg3raSOraqbQGSqZP988sOaMdpA2wj3Dr6ykOscrMukyK3U6edxhpS0N8kguAFZoHwCEfTig==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*",
-				"playwright-core": "1.23.2"
+				"playwright": "1.59.1"
 			}
 		},
-		"@types/node": {
-			"version": "18.0.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-			"integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
-			"dev": true
+		"fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"optional": true
 		},
 		"node-addon-api": {
 			"version": "8.3.1",
@@ -131,10 +156,20 @@
 			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
 			"dev": true
 		},
+		"playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"dev": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.59.1"
+			}
+		},
 		"playwright-core": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.2.tgz",
-			"integrity": "sha512-UGbutIr0nBALDHWW/HcXfyK6ZdmefC99Moo4qyTr89VNIkYZuDrW8Sw554FyFUamcFSdKOgDPk6ECSkofGIZjQ==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true
 		},
 		"tree-sitter-c-sharp": {

--- a/anycode-c-sharp/package.json
+++ b/anycode-c-sharp/package.json
@@ -40,7 +40,6 @@
 		"test": "node ../anycode/server/src/common/test-fixture/test.js  --outline ./fixtures/outline.cs --highlights ./fixtures/highlights.cs"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.14.1",
 		"tree-sitter-cli": "^0.20.8",
 		"tree-sitter-c-sharp": "^0.23.1"
 	}

--- a/anycode-cpp/package.json
+++ b/anycode-cpp/package.json
@@ -71,7 +71,6 @@
 		"test": "node ../anycode/server/src/common/test-fixture/test.js  --outline ./fixtures/outline.c"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.14.1",
 		"tree-sitter-cli": "^0.20.8",
 		"tree-sitter-cpp": "^0.20.5",
 		"tree-sitter-c": "^0.20.8"

--- a/anycode-go/package.json
+++ b/anycode-go/package.json
@@ -40,7 +40,6 @@
 		"test": "node ../anycode/server/src/common/test-fixture/test.js  --outline ./fixtures/outline.go --highlights ./fixtures/highlights.go"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.14.1",
 		"tree-sitter-cli": "^0.20.8",
 		"tree-sitter-go": "^0.23.4"
 	}

--- a/anycode-php/package.json
+++ b/anycode-php/package.json
@@ -44,7 +44,6 @@
 		"test": "node ../anycode/server/src/common/test-fixture/test.js --highlights ./fixtures/highlights.php"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.14.1",
 		"tree-sitter-cli": "^0.20.8",
 		"tree-sitter-php": "^0.20.0"
 	}

--- a/anycode-python/package.json
+++ b/anycode-python/package.json
@@ -47,7 +47,6 @@
 		"test": "node ../anycode/server/src/common/test-fixture/test.js  --outline ./fixtures/outline.ts --highlights ./fixtures/highlights.ts"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.14.1",
 		"tree-sitter-cli": "^0.20.8",
 		"tree-sitter-python": "^0.20.4"
 	}

--- a/anycode-typescript/package.json
+++ b/anycode-typescript/package.json
@@ -40,7 +40,6 @@
 		"test": "node ../anycode/server/src/common/test-fixture/test.js  --outline ./fixtures/outline.ts --highlights ./fixtures/highlights.ts"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.14.1",
 		"tree-sitter-cli": "^0.20.8",
 		"tree-sitter-typescript": "^0.20.3"
 	}

--- a/anycode/package.json
+++ b/anycode/package.json
@@ -107,9 +107,9 @@
 	],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -b tsconfig.json && node esbuild.js",
+		"compile": "tsc -b tsconfig.json && node esbuild.mjs",
 		"watch": "node esbuild.mjs --watch",
-		"postinstall": "cd client && npm install && cd ../server && npm install && cd .. && node esbuild.js",
+		"postinstall": "cd client && npm install && cd ../server && npm install && cd .. && node esbuild.mjs",
 		"lint": "eslint client server --ext ts",
 		"deploy": "npx vsce publish --noVerify",
 		"pretest-extension": "npx esbuild client/src/test/suite/index.ts --bundle --external:vscode --target=es2020 --format=cjs --outfile=dist/extension.test.js --define:process=\"{\\\"env\\\":{}}\"",


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that runs on every PR, and cleans up stale/unused dependencies in the language subpackages.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Playwright install location**: `test.js` resolves `playwright` from `anycode/server/node_modules/` (where it's listed as a devDependency at `^1.58.2`). Running `npx playwright install` must be done from `anycode/server/` to get the matching browser binaries - not from the language-specific packages. The CI workflow reflects this.

- **`@playwright/test` removed from language packages**: The 6 language packages that had `@playwright/test` as a devDependency never actually used it - `test.js` imports from `playwright` (not `@playwright/test`) and resolves it from the server's node_modules. These were stale entries. `anycode-kotlin`, `-java`, and `-rust` never had this dependency and were not affected.

- **Single CI job (not matrix)**: The language package tests are sequential steps in one job rather than a parallel matrix. This keeps the Playwright browser install shared and avoids the complexity of a matrix setup for what are simple fixture tests.

- **`esbuild.js` -> `esbuild.mjs`**: The `compile` and `postinstall` scripts in `anycode/package.json` referenced `esbuild.js` which no longer exists (file is `esbuild.mjs`). Fixed as a separate commit.

</details>

## Changes

- `anycode/package.json`: fix `compile` and `postinstall` scripts to reference `esbuild.mjs`
- `anycode-{c-sharp,cpp,go,php,python,typescript}/package.json`: remove unused `@playwright/test` devDependency
- `.github/workflows/ci.yml`: new CI workflow that runs on PRs - installs, lints, runs server tests, installs Playwright from the correct location, then runs all 9 language package test fixtures
